### PR TITLE
Link fix. Minor spelling fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Are you enjoying how easy BossDB makes it to use our publicly hosted data and wa
 ## Jupyter Notebooks
 In the `notebooks` folder we have jupyter notebooks with more advanced examples of interacting with the BossDB system
 
-- [Five Minute Jumpstart](https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Five-Minute-Jumpstart.ipynb)
+- [Five Minute Jumpstart](https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Five-Minute-Jump-Start.ipynb)
 - [Advanced Getting Started](https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Get-Started-Downloading-Data-with-Intern.ipynb)
 - [Custom Dataset Classes for Pytorch](https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/BossDB-Dataset-Classes-for-Pytorch-DataLoaders.ipynb)
 - [Accessing Downsampled Versions of Data on BossDB](https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Accessing-Lower-Resolution-Versions-Of-Data-From-BossDB.ipynb)

--- a/docs/BossDB-Set-Up-For-Private-Datasets.md
+++ b/docs/BossDB-Set-Up-For-Private-Datasets.md
@@ -10,7 +10,7 @@ To create an account, navigate to [api.bossdb.io](api.bossdb.io). You will be pr
 
 I recommend taking the tour of the management console by clicking the **Tour** button at the top right of the page. 
 
-## [Boss Mangement Console](https://api.bossdb.io/v1/mgmt/)
+## [Boss Management Console](https://api.bossdb.io/v1/mgmt/)
 
 The boss management console will show you which datasets you have access to and which permissions groups you belong to. 
 

--- a/docs/How-To-Upload-Data-To-BossDB.md
+++ b/docs/How-To-Upload-Data-To-BossDB.md
@@ -18,7 +18,7 @@ Typically we use intern for anything smaller than 25 GB of data. If we are uploa
 
 Just like how we need a collection, experiment, and channel to download data,  we need to create a new collection, experiment, and channel to upload data. 
 
-There are also two ways to set up a resource. You can do this through `intern` directly or through the management console. We recommend using the managment console for set up if only uploading a single or a few datasets at a time. 
+There are also two ways to set up a resource. You can do this through `intern` directly or through the management console. We recommend using the management console for set up if only uploading a single or a few datasets at a time. 
 
 Please view the [API documentation](https://docs.theboss.io/docs/list-collections) for more detailed information!
 
@@ -42,7 +42,7 @@ Most of the fields for a coordinate frame are pretty self-explanatory but there 
 
 **Experiment Name:**
 
-The experiment name must be unique to the specfic collection. This might be the name for a particular subject (e.g. mouse_1) as the channels within the experiment should all be co-registered data.
+The experiment name must be unique to the specific collection. This might be the name for a particular subject (e.g. mouse_1) as the channels within the experiment should all be co-registered data.
 
 **Channel Name:**
 
@@ -59,7 +59,7 @@ Navigate to the management console website and log in: https://api.bossdb.io/
 
 *Step 1: Collection Name and Description*
 
-Once there, you can click "Manage Resources" and then "Add Collection". A modal will pop up where you can fill in the Collection name and a short description. You can also decide to make the datset public or not.
+Once there, you can click "Manage Resources" and then "Add Collection". A modal will pop up where you can fill in the Collection name and a short description. You can also decide to make the dataset public or not.
 
 Once you've created the collection, find your collection name and click the "Details" button to the right of the name. (You might have to filter by the name or scroll through some pages to find the collection you created). 
 
@@ -82,8 +82,8 @@ A modal will pop up with a form to fill out.
 - Add the name and a short description of the experiment.
 - Provide the name of the coordinate frame you just created.
 - Num hierarchy levels lets bossDB know how many levels of downsample this dataset should have.
-- Heirarchy method is either isotropic or anisotropic and it will depend on your dataset voxel resolution
-- num time samples is relevent if using timeseries data otherwise it is 1. 
+- Hierarchy method is either isotropic or anisotropic and it will depend on your dataset voxel resolution
+- num time samples is relevant if using timeseries data otherwise it is 1. 
 - time step information is only relevant if timeseries data and can be left empty
 
 Similar to collection, you can click the "Details" button on the experiment and scroll down to permissions

--- a/docs/IARPA_MICrONS_Pinky_100_Dataset.md
+++ b/docs/IARPA_MICrONS_Pinky_100_Dataset.md
@@ -1,7 +1,7 @@
 # IARPA MICrONS Pinky 100 Dataset
 
 
-This dataset was collected as part of the [Machine Intelligenece from Cortical Networks (MICrONS)](https://www.iarpa.gov/index.php/research-programs/microns) project, which seeks to revolutionize machine learning by reverse-engineering the algorithms of the brain.
+This dataset was collected as part of the [Machine Intelligence from Cortical Networks (MICrONS)](https://www.iarpa.gov/index.php/research-programs/microns) project, which seeks to revolutionize machine learning by reverse-engineering the algorithms of the brain.
 
 
 This dataset consists of Electron Microscopy (EM) image data, segmentation data, and corresponding meshes of the cortical circuitry from the mouse visual cortex. This dataset was acquired and analyzed in the initial phase of the MICrONS project. It is a 250 x 140 x 90 µm volume from layer 2/3 of a P36 male mouse visual cortex imaged at 3.58 x 3.58 x 40 nm resolution with a dense segmentation, proofreading of all dendrites and axons of the 364 excitatory neurons in the volume, and dense synapse detection.

--- a/notebooks/Accessing-Lower-Resolution-Versions-Of-Data-From-BossDB.ipynb
+++ b/notebooks/Accessing-Lower-Resolution-Versions-Of-Data-From-BossDB.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "[https://api.bossdb.io/v1/mgmt/resources/prasad/prasad2020](https://api.bossdb.io/v1/mgmt/resources/prasad/prasad2020) for this dataset you can see that there are 7 levels of downsampling.\n",
     "\n",
-    "Next, check the `Channel Details` page. If a dataset has been downsampled you will see a green box with 'Downsampled' next to 'Downsampled Status' at the top of the channel details page. See here for an example of a channel taht has been downsampled: [https://api.bossdb.io/v1/mgmt/resources/prasad/prasad2020/image](https://api.bossdb.io/v1/mgmt/resources/prasad/prasad2020/image) "
+    "Next, check the `Channel Details` page. If a dataset has been downsampled you will see a green box with 'Downsampled' next to 'Downsampled Status' at the top of the channel details page. See here for an example of a channel that has been downsampled: [https://api.bossdb.io/v1/mgmt/resources/prasad/prasad2020/image](https://api.bossdb.io/v1/mgmt/resources/prasad/prasad2020/image) "
    ]
   },
   {


### PR DESCRIPTION
I found a broken link in the README (Jumpstart -> Jump-Start) and a couple other minor spelling fixes flagged by my VSCode extension cspell

- Mangement -> Management
- Intelligenece -> Intelligence
- taht -> that

Lmk if there are any other PR procedures to follow.